### PR TITLE
Fix logout flow and auth validation feedback

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -14,6 +14,11 @@ export type LoginResponse = {
   redirectPath: '/admin' | '/tenant';
 };
 
+export type BasicApiResponse = {
+  success: boolean;
+  message: string;
+};
+
 class ApiClient {
   private client: AxiosInstance;
 
@@ -115,20 +120,43 @@ class ApiClient {
     }
   }
 
+  async logout(): Promise<BasicApiResponse | undefined> {
+    try {
+      const response = await this.client.post('/logout');
+      return response.data;
+    } catch (error) {
+      this.handleError(error);
+      return undefined;
+    }
+  }
+
   // Handle common errors
   handleError(error: any) {
+    let toastMessage = 'Something went wrong';
+
     if (error.response) {
       // Server responded with a status other than 2xx
-      console.error(`API Error: ${error.response.status} - ${error.response.data.message}`);
+      const status = error.response.status;
+      const data = error.response.data ?? {};
+      const errorGroups = data.errors ? Object.values(data.errors) : [];
+      const firstValidationMessage =
+        Array.isArray(errorGroups) && errorGroups.length > 0 && Array.isArray(errorGroups[0])
+          ? String(errorGroups[0][0])
+          : undefined;
+
+      toastMessage = firstValidationMessage || data.message || `Request failed with status code ${status}`;
+      console.error(`API Error: ${status} - ${toastMessage}`);
     } else if (error.request) {
       // Request was made, but no response was received
       console.error('API Error: No response received', error.request);
+      toastMessage = 'No response from server. Check backend and database are running.';
     } else {
       // Something went wrong while setting up the request
       console.error('API Error:', error.message);
+      toastMessage = error.message || toastMessage;
     }
 
-    toast.error(error.message || 'Something went wrong');
+    toast.error(toastMessage);
   }
 }
 

--- a/client/src/views/DashboardLayout.tsx
+++ b/client/src/views/DashboardLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import { ListGroup, Button } from 'react-bootstrap';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -9,6 +9,8 @@ import {
   BsChatDots,
   BsBoxArrowRight,
 } from 'react-icons/bs';
+import ApiClient from '../api';
+import { clearStoredAuthUser } from '../helpers/auth';
 
 interface DashboardLayoutProps {
   role: 'Admin' | 'Tenant';
@@ -18,9 +20,23 @@ interface DashboardLayoutProps {
 export function DashboardLayout({ role, children }: DashboardLayoutProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const api = useMemo(() => new ApiClient(), []);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
 
-  const handleLogout = () => {
-    navigate('/login');
+  const handleLogout = async () => {
+    if (isLoggingOut) {
+      return;
+    }
+
+    setIsLoggingOut(true);
+
+    try {
+      await api.logout();
+    } finally {
+      clearStoredAuthUser();
+      navigate('/login', { replace: true });
+      setIsLoggingOut(false);
+    }
   };
 
   const isActive = (path: string) => location.pathname === path;
@@ -73,9 +89,10 @@ export function DashboardLayout({ role, children }: DashboardLayoutProps) {
             variant="link"
             className="d-inline-flex align-items-center gap-1 p-0 text-dark text-decoration-none fw-semibold"
             onClick={handleLogout}
+            disabled={isLoggingOut}
           >
             <BsBoxArrowRight size={14} />
-            Logout
+            {isLoggingOut ? 'Logging out...' : 'Logout'}
           </Button>
         </header>
         <main className="p-4">{children}</main>

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -26,6 +26,9 @@ export default function Login() {
     setIsSubmitting(false);
 
     if (!response?.success) {
+      if (response?.message) {
+        toast.error(response.message);
+      }
       return;
     }
 

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -36,6 +36,11 @@ export default function Register() {
       return;
     }
 
+    if (input.password.length < 8) {
+      toast.error('Password must be at least 8 characters.');
+      return;
+    }
+
     setIsSubmitting(true);
     const response = await api.register(
       input.name,
@@ -46,6 +51,9 @@ export default function Register() {
     setIsSubmitting(false);
 
     if (!response?.success) {
+      if (response?.message) {
+        toast.error(response.message);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- add frontend logout API helper
- clear stored auth user on logout and redirect reliably to login
- disable logout button while request is in progress
- improve error toasts to show backend validation messages
- add client-side password length check before register submit

## Validation
- npm run build in client passes

closes #26