### PR TITLE
[AUTH][Backend] Replace hardcoded admin middleware with role-based authorization

### DIFF
--- a/server/app/Http/Middleware/CheckAdminCredentials.php
+++ b/server/app/Http/Middleware/CheckAdminCredentials.php
@@ -4,23 +4,25 @@ namespace App\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Exception;
 
 class CheckAdminCredentials
 {
     public function handle(Request $request, Closure $next)
     {
-        $sessionData = $request->validate([
-            'username' => 'required|string',
-            'password' => 'required|string'
-        ]);
+        $user = $request->user();
 
-        if (!$sessionData) {
-            throw new Exception("Credentials required");
+        if (!$user) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Unauthenticated.',
+            ], 401);
         }
 
-        if ($request->username !== 'admin' || $request->password !== 'adminadmin') {
-            throw new Exception("Incorrect credentials");
+        if (data_get($user, 'role') !== 'admin') {
+            return response()->json([
+                'success' => false,
+                'message' => 'Forbidden. Admin access required.',
+            ], 403);
         }
 
         return $next($request);

--- a/server/tests/Feature/Auth/CheckAdminCredentialsTest.php
+++ b/server/tests/Feature/Auth/CheckAdminCredentialsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Http\Middleware\CheckAdminCredentials;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class CheckAdminCredentialsTest extends TestCase
+{
+    public function test_admin_middleware_returns_401_for_unauthenticated_requests()
+    {
+        $request = Request::create('/api/session', 'POST');
+        $middleware = new CheckAdminCredentials();
+
+        $response = $middleware->handle($request, function () {
+            return response()->json(['success' => true], 200);
+        });
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame([
+            'success' => false,
+            'message' => 'Unauthenticated.',
+        ], $response->getData(true));
+    }
+
+    public function test_admin_middleware_returns_403_for_non_admin_users()
+    {
+        $request = Request::create('/api/session', 'POST');
+        $request->setUserResolver(function () {
+            return (object) ['id' => 10, 'role' => 'tenant'];
+        });
+
+        $middleware = new CheckAdminCredentials();
+
+        $response = $middleware->handle($request, function () {
+            return response()->json(['success' => true], 200);
+        });
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame([
+            'success' => false,
+            'message' => 'Forbidden. Admin access required.',
+        ], $response->getData(true));
+    }
+
+    public function test_admin_middleware_allows_admin_users()
+    {
+        $request = Request::create('/api/session', 'POST');
+        $request->setUserResolver(function () {
+            return (object) ['id' => 1, 'role' => 'admin'];
+        });
+
+        $middleware = new CheckAdminCredentials();
+
+        $response = $middleware->handle($request, function () {
+            return response()->json(['success' => true], 200);
+        });
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame([
+            'success' => true,
+        ], $response->getData(true));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded admin credential checks with authenticated role-based authorization in middleware.
- Return 401 for unauthenticated requests and 403 for non-admin users.
- Add focused feature tests for 401 / 403 / 200 paths.

## Verification
- php artisan test --filter=CheckAdminCredentialsTest (pass: 3 tests)

closes #28