### PR TITLE
[AUTH][Backend] Enforce tenant-only public registration and block role injection

### DIFF
--- a/server/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/server/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -26,8 +26,8 @@ class RegisteredUserController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
-            // Self-registration only allows tenant accounts.
-            'role' => ['sometimes', 'in:tenant'],
+            // Public registration must not accept role elevation input.
+            'role' => ['prohibited'],
         ]);
 
         if ($validator->fails()) {

--- a/server/tests/Feature/Auth/RegistrationTest.php
+++ b/server/tests/Feature/Auth/RegistrationTest.php
@@ -2,12 +2,33 @@
 
 namespace Tests\Feature\Auth;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
-    use RefreshDatabase;
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('role', ['admin', 'tenant'])->default('tenant');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
 
     public function test_new_users_can_register()
     {
@@ -18,7 +39,46 @@ class RegistrationTest extends TestCase
             'password_confirmation' => 'password',
         ]);
 
-        $this->assertAuthenticated();
-        $response->assertNoContent();
+        $this->assertGuest();
+        $response
+            ->assertStatus(201)
+            ->assertJson([
+                'success' => true,
+                'message' => 'User registered successfully.',
+                'user' => [
+                    'email' => 'test@example.com',
+                    'role' => 'tenant',
+                ],
+            ]);
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+            'role' => 'tenant',
+        ]);
+    }
+
+    public function test_public_registration_rejects_role_input()
+    {
+        $response = $this->post('/register', [
+            'name' => 'Admin Attempt',
+            'email' => 'admin-attempt@example.com',
+            'password' => 'password',
+            'password_confirmation' => 'password',
+            'role' => 'admin',
+        ]);
+
+        $response
+            ->assertStatus(422)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Validation failed.',
+            ])
+            ->assertJsonValidationErrors(['role']);
+
+        $this->assertDatabaseMissing('users', [
+            'email' => 'admin-attempt@example.com',
+        ]);
+
+        $this->assertSame(0, User::where('role', 'admin')->where('email', 'admin-attempt@example.com')->count());
     }
 }


### PR DESCRIPTION
## Summary
- Harden public registration by prohibiting role field in request payload.
- Keep server-side role assignment fixed to tenant.
- Add registration tests for standard signup and role injection rejection.
- Make registration tests self-contained by creating the users table schema in test setup.

## Verification
- php artisan test --filter=RegistrationTest (pass: 2 tests)

closes #30