### PR TITLE
[AUTH][Backend] Seed default admin account from environment

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -13,3 +13,8 @@ DB_PORT=3306
 DB_DATABASE=attendance_tracker
 DB_USERNAME=root
 DB_PASSWORD=
+
+# Trusted bootstrap admin seed values (used by Database\\Seeders\\DefaultAdminSeeder).
+DEFAULT_ADMIN_NAME=
+DEFAULT_ADMIN_EMAIL=
+DEFAULT_ADMIN_PASSWORD=

--- a/server/database/seeders/DatabaseSeeder.php
+++ b/server/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     */
+    public function run(): void
+    {
+        $this->call([
+            DefaultAdminSeeder::class,
+        ]);
+    }
+}

--- a/server/database/seeders/DefaultAdminSeeder.php
+++ b/server/database/seeders/DefaultAdminSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class DefaultAdminSeeder extends Seeder
+{
+    /**
+     * Seed a default admin account from environment configuration.
+     */
+    public function run(): void
+    {
+        $name = env('DEFAULT_ADMIN_NAME');
+        $email = env('DEFAULT_ADMIN_EMAIL');
+        $password = env('DEFAULT_ADMIN_PASSWORD');
+
+        if (!$name || !$email || !$password) {
+            $this->command?->warn('Skipping default admin seed: DEFAULT_ADMIN_NAME/EMAIL/PASSWORD not fully configured.');
+            return;
+        }
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->command?->warn('Skipping default admin seed: DEFAULT_ADMIN_EMAIL is invalid.');
+            return;
+        }
+
+        User::updateOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name,
+                'password' => Hash::make($password),
+                'role' => 'admin',
+            ]
+        );
+
+        $this->command?->info("Default admin account seeded/updated for {$email}.");
+    }
+}

--- a/server/tests/Feature/Auth/DefaultAdminSeederTest.php
+++ b/server/tests/Feature/Auth/DefaultAdminSeederTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Database\Seeders\DefaultAdminSeeder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class DefaultAdminSeederTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('role', ['admin', 'tenant'])->default('tenant');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_default_admin_seeder_creates_admin_from_env(): void
+    {
+        putenv('DEFAULT_ADMIN_NAME=Seed Admin');
+        putenv('DEFAULT_ADMIN_EMAIL=seed-admin@example.com');
+        putenv('DEFAULT_ADMIN_PASSWORD=StrongPassword123');
+
+        (new DefaultAdminSeeder())->run();
+
+        $admin = User::where('email', 'seed-admin@example.com')->first();
+
+        $this->assertNotNull($admin);
+        $this->assertSame('Seed Admin', $admin->name);
+        $this->assertSame('admin', $admin->role);
+        $this->assertTrue(Hash::check('StrongPassword123', $admin->password));
+    }
+
+    public function test_default_admin_seeder_updates_existing_record_without_duplication(): void
+    {
+        User::create([
+            'name' => 'Old Name',
+            'email' => 'seed-admin@example.com',
+            'password' => Hash::make('old-pass'),
+            'role' => 'tenant',
+        ]);
+
+        putenv('DEFAULT_ADMIN_NAME=Updated Admin');
+        putenv('DEFAULT_ADMIN_EMAIL=seed-admin@example.com');
+        putenv('DEFAULT_ADMIN_PASSWORD=UpdatedStrongPassword');
+
+        (new DefaultAdminSeeder())->run();
+        (new DefaultAdminSeeder())->run();
+
+        $this->assertSame(1, User::where('email', 'seed-admin@example.com')->count());
+
+        $admin = User::where('email', 'seed-admin@example.com')->first();
+
+        $this->assertSame('Updated Admin', $admin->name);
+        $this->assertSame('admin', $admin->role);
+        $this->assertTrue(Hash::check('UpdatedStrongPassword', $admin->password));
+    }
+}


### PR DESCRIPTION
## Summary
- Add trusted default admin seed path using environment-configured credentials.
- Create an idempotent seeder that upserts admin by email and forces role=admin.
- Skip seed when required env values are missing or invalid.
- Add focused tests for creation and idempotent update behavior.

## Verification
- php artisan test --filter=DefaultAdminSeederTest (pass: 2 tests)

closes #32