### PR TITLE
[AUTH][Backend] Add CLI command to create admin accounts

### DIFF
--- a/server/app/Console/Commands/CreateAdminUserCommand.php
+++ b/server/app/Console/Commands/CreateAdminUserCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+
+class CreateAdminUserCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:create-admin
+                            {email : Email of the admin account}
+                            {--name= : Name of the admin account}
+                            {--password= : Password for the admin account}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create or update an admin account from terminal';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $email = (string) $this->argument('email');
+        $name = (string) ($this->option('name') ?: $this->ask('Admin name'));
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->error('Invalid email format.');
+            return self::FAILURE;
+        }
+
+        if ($name === '') {
+            $this->error('Admin name is required.');
+            return self::FAILURE;
+        }
+
+        $passwordOption = $this->option('password');
+        $password = is_string($passwordOption) && $passwordOption !== ''
+            ? $passwordOption
+            : (string) $this->secret('Admin password');
+
+        if (strlen($password) < 8) {
+            $this->error('Password must be at least 8 characters.');
+            return self::FAILURE;
+        }
+
+        $user = User::updateOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name,
+                'password' => Hash::make($password),
+                'role' => 'admin',
+            ]
+        );
+
+        $this->info("Admin account ready: {$user->email}");
+        return self::SUCCESS;
+    }
+}

--- a/server/tests/Feature/Auth/CreateAdminUserCommandTest.php
+++ b/server/tests/Feature/Auth/CreateAdminUserCommandTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class CreateAdminUserCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('role', ['admin', 'tenant'])->default('tenant');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_command_creates_admin_user(): void
+    {
+        $exitCode = Artisan::call('user:create-admin', [
+            'email' => 'cli-admin@example.com',
+            '--name' => 'CLI Admin',
+            '--password' => 'StrongPass123',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $admin = User::where('email', 'cli-admin@example.com')->first();
+
+        $this->assertNotNull($admin);
+        $this->assertSame('CLI Admin', $admin->name);
+        $this->assertSame('admin', $admin->role);
+        $this->assertTrue(Hash::check('StrongPass123', $admin->password));
+    }
+
+    public function test_command_upgrades_existing_user_to_admin(): void
+    {
+        User::create([
+            'name' => 'Old Tenant',
+            'email' => 'existing@example.com',
+            'password' => Hash::make('old-password'),
+            'role' => 'tenant',
+        ]);
+
+        $exitCode = Artisan::call('user:create-admin', [
+            'email' => 'existing@example.com',
+            '--name' => 'Updated Admin',
+            '--password' => 'UpdatedPass123',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(1, User::where('email', 'existing@example.com')->count());
+
+        $admin = User::where('email', 'existing@example.com')->first();
+
+        $this->assertSame('Updated Admin', $admin->name);
+        $this->assertSame('admin', $admin->role);
+        $this->assertTrue(Hash::check('UpdatedPass123', $admin->password));
+    }
+}


### PR DESCRIPTION
## Summary
- Add trusted Artisan command: user:create-admin.
- Command creates or updates user by email and forces role=admin.
- Password is hashed securely before storage.
- Add focused tests for create and upgrade-to-admin paths.

## Verification
- php artisan test --filter=CreateAdminUserCommandTest (pass: 2 tests)

closes #34