### PR TITLE
[AUTH][Backend] Add admin-only API to create users

### DIFF
--- a/server/app/Http/Controllers/Admin/UserManagementController.php
+++ b/server/app/Http/Controllers/Admin/UserManagementController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules;
+
+class UserManagementController extends Controller
+{
+    /**
+     * Create a user from admin context.
+     */
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+            'role' => ['required', 'in:admin,tenant'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $validated = $validator->validated();
+
+        $user = User::create([
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
+            'role' => $validated['role'],
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'User created successfully.',
+            'user' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'role' => $user->role,
+            ],
+        ], 201);
+    }
+}

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\SessionController;
+use App\Http\Controllers\Admin\UserManagementController;
 
 /*
 |--------------------------------------------------------------------------
@@ -23,4 +24,5 @@ Route::get('/session', [SessionController::class, 'getSession']);
 Route::post('/session', [SessionController::class, 'createSession'])->middleware('check.admin');
 Route::put('/session', [SessionController::class, 'updateSession'])->middleware('check.admin');
 Route::post('/sessions', [SessionController::class, 'viewSessions'])->middleware('check.admin');
+Route::post('/admin/users', [UserManagementController::class, 'store'])->middleware('check.admin');
 Route::post('/attendance', [SessionController::class, 'submitAttendance']);

--- a/server/tests/Feature/Auth/AdminCreateUserApiTest.php
+++ b/server/tests/Feature/Auth/AdminCreateUserApiTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\User;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AdminCreateUserApiTest extends TestCase
+{
+    use WithFaker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists('users');
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->enum('role', ['admin', 'tenant'])->default('tenant');
+            $table->timestamps();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists('users');
+        parent::tearDown();
+    }
+
+    public function test_unauthenticated_user_cannot_create_users(): void
+    {
+        $response = $this->postJson('/api/admin/users', [
+            'name' => 'New User',
+            'email' => 'new-user@example.com',
+            'password' => 'StrongPass123',
+            'password_confirmation' => 'StrongPass123',
+            'role' => 'tenant',
+        ]);
+
+        $response
+            ->assertStatus(401)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Unauthenticated.',
+            ]);
+    }
+
+    public function test_tenant_cannot_create_users(): void
+    {
+        $tenant = User::create([
+            'name' => 'Tenant User',
+            'email' => 'tenant@example.com',
+            'password' => Hash::make('password123'),
+            'role' => 'tenant',
+        ]);
+
+        $response = $this->actingAs($tenant)->postJson('/api/admin/users', [
+            'name' => 'Blocked User',
+            'email' => 'blocked@example.com',
+            'password' => 'StrongPass123',
+            'password_confirmation' => 'StrongPass123',
+            'role' => 'tenant',
+        ]);
+
+        $response
+            ->assertStatus(403)
+            ->assertJson([
+                'success' => false,
+                'message' => 'Forbidden. Admin access required.',
+            ]);
+    }
+
+    public function test_admin_can_create_user_with_selected_role(): void
+    {
+        $admin = User::create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password123'),
+            'role' => 'admin',
+        ]);
+
+        $response = $this->actingAs($admin)->postJson('/api/admin/users', [
+            'name' => 'Created Admin',
+            'email' => 'created-admin@example.com',
+            'password' => 'StrongPass123',
+            'password_confirmation' => 'StrongPass123',
+            'role' => 'admin',
+        ]);
+
+        $response
+            ->assertStatus(201)
+            ->assertJson([
+                'success' => true,
+                'message' => 'User created successfully.',
+                'user' => [
+                    'email' => 'created-admin@example.com',
+                    'role' => 'admin',
+                ],
+            ]);
+
+        $created = User::where('email', 'created-admin@example.com')->first();
+
+        $this->assertNotNull($created);
+        $this->assertSame('admin', $created->role);
+        $this->assertTrue(Hash::check('StrongPass123', $created->password));
+    }
+}


### PR DESCRIPTION
## Summary
- add admin-only endpoint to create users: `POST /api/admin/users`
- implement `UserManagementController@store` with validation, hashing, and role support (`admin|tenant`)
- cover unauthenticated, non-admin, and admin-success flows with feature tests

## Testing
- php artisan test --filter=AdminCreateUserApiTest

closes #36
