### PR TITLE
[AUTH][Frontend] Add admin dashboard UI to create users

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Register from './views/Register';
 import AdminDashboard from './views/AdminDashboard';
 import TenantDashboard from './views/TenantDashboard';
 import ApartmentManagement from './views/ApartmentManagement';
+import AdminUserManagement from './views/AdminUserManagement';
 import ComplaintsPage from './views/ComplaintsPage';
 import LeaseDetailsPage from './views/LeaseDetailsPage';
 import DocumentsPage from './views/DocumentsPage';
@@ -114,6 +115,14 @@ function App() {
             element={
               <RoleGuard role="admin">
                 <ComplaintsPage role="Admin" />
+              </RoleGuard>
+            }
+          />
+          <Route
+            path="/admin/users"
+            element={
+              <RoleGuard role="admin">
+                <AdminUserManagement />
               </RoleGuard>
             }
           />

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -19,6 +19,17 @@ export type BasicApiResponse = {
   message: string;
 };
 
+export type AdminCreateUserResponse = {
+  success: boolean;
+  message: string;
+  user: {
+    id: number;
+    name: string;
+    email: string;
+    role: 'admin' | 'tenant';
+  };
+};
+
 class ApiClient {
   private client: AxiosInstance;
 
@@ -123,6 +134,29 @@ class ApiClient {
   async logout(): Promise<BasicApiResponse | undefined> {
     try {
       const response = await this.client.post('/logout');
+      return response.data;
+    } catch (error) {
+      this.handleError(error);
+      return undefined;
+    }
+  }
+
+  async createAdminUser(
+    name: string,
+    email: string,
+    password: string,
+    password_confirmation: string,
+    role: 'admin' | 'tenant'
+  ): Promise<AdminCreateUserResponse | undefined> {
+    try {
+      const response = await this.client.post('/api/admin/users', {
+        name,
+        email,
+        password,
+        password_confirmation,
+        role,
+      });
+
       return response.data;
     } catch (error) {
       this.handleError(error);

--- a/client/src/views/AdminDashboard.tsx
+++ b/client/src/views/AdminDashboard.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { DashboardLayout } from './DashboardLayout';
-import { BsBuilding, BsFileEarmarkText, BsChatDots } from 'react-icons/bs';
+import { BsBuilding, BsFileEarmarkText, BsChatDots, BsPeople } from 'react-icons/bs';
 
 export default function AdminDashboard() {
   const navigate = useNavigate();
@@ -9,6 +9,7 @@ export default function AdminDashboard() {
   const quickActions = useMemo(
     () => [
       { label: 'Apartments & Tenants', icon: BsBuilding, to: '/admin/apartments' },
+      { label: 'Create Users', icon: BsPeople, to: '/admin/users' },
       { label: 'Lease Details', icon: BsFileEarmarkText, to: '/admin/lease' },
       { label: 'View Complaints', icon: BsChatDots, to: '/admin/complaints' },
     ],

--- a/client/src/views/AdminUserManagement.tsx
+++ b/client/src/views/AdminUserManagement.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from 'react';
+import { Button, Card, Col, Form, Row } from 'react-bootstrap';
+import toast from 'react-hot-toast';
+import ApiClient from '../api';
+import { DashboardLayout } from './DashboardLayout';
+
+type RoleOption = 'admin' | 'tenant';
+
+type FormState = {
+  name: string;
+  email: string;
+  role: RoleOption;
+  password: string;
+  password_confirmation: string;
+};
+
+const INITIAL_FORM: FormState = {
+  name: '',
+  email: '',
+  role: 'tenant',
+  password: '',
+  password_confirmation: '',
+};
+
+export default function AdminUserManagement() {
+  const api = useMemo(() => new ApiClient(), []);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [form, setForm] = useState<FormState>(INITIAL_FORM);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleRoleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const role = event.target.value as RoleOption;
+    setForm((prev) => ({ ...prev, role }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (form.password !== form.password_confirmation) {
+      toast.error('Password confirmation does not match.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    const response = await api.createAdminUser(
+      form.name,
+      form.email,
+      form.password,
+      form.password_confirmation,
+      form.role
+    );
+    setIsSubmitting(false);
+
+    if (!response?.success) {
+      return;
+    }
+
+    toast.success(`User ${response.user.email} created successfully.`);
+    setForm(INITIAL_FORM);
+  };
+
+  return (
+    <DashboardLayout role="Admin">
+      <div style={{ background: '#e8f0ff', minHeight: '100vh' }}>
+        <div className="container-fluid">
+          <div className="mb-4">
+            <h2 className="mb-1">User Management</h2>
+            <p className="text-muted mb-0">Create admin or tenant accounts from the dashboard.</p>
+          </div>
+
+          <Row>
+            <Col xs={12} lg={8} xl={6}>
+              <Card className="p-4 shadow-sm">
+                <h5 className="mb-3">Create New User</h5>
+
+                <Form onSubmit={handleSubmit}>
+                  <Form.Group className="mb-3" controlId="createUserName">
+                    <Form.Label>Full Name</Form.Label>
+                    <Form.Control
+                      type="text"
+                      name="name"
+                      value={form.name}
+                      onChange={handleInputChange}
+                      required
+                      placeholder="Enter full name"
+                    />
+                  </Form.Group>
+
+                  <Form.Group className="mb-3" controlId="createUserEmail">
+                    <Form.Label>Email</Form.Label>
+                    <Form.Control
+                      type="email"
+                      name="email"
+                      value={form.email}
+                      onChange={handleInputChange}
+                      required
+                      placeholder="name@example.com"
+                    />
+                  </Form.Group>
+
+                  <Form.Group className="mb-3" controlId="createUserRole">
+                    <Form.Label>Role</Form.Label>
+                    <Form.Select name="role" value={form.role} onChange={handleRoleChange}>
+                      <option value="tenant">Tenant</option>
+                      <option value="admin">Admin</option>
+                    </Form.Select>
+                  </Form.Group>
+
+                  <Form.Group className="mb-3" controlId="createUserPassword">
+                    <Form.Label>Password</Form.Label>
+                    <Form.Control
+                      type="password"
+                      name="password"
+                      value={form.password}
+                      onChange={handleInputChange}
+                      required
+                      placeholder="Enter password"
+                    />
+                  </Form.Group>
+
+                  <Form.Group className="mb-4" controlId="createUserPasswordConfirmation">
+                    <Form.Label>Confirm Password</Form.Label>
+                    <Form.Control
+                      type="password"
+                      name="password_confirmation"
+                      value={form.password_confirmation}
+                      onChange={handleInputChange}
+                      required
+                      placeholder="Confirm password"
+                    />
+                  </Form.Group>
+
+                  <div className="d-flex gap-2">
+                    <Button type="submit" disabled={isSubmitting}>
+                      {isSubmitting ? 'Creating...' : 'Create User'}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline-secondary"
+                      onClick={() => setForm(INITIAL_FORM)}
+                      disabled={isSubmitting}
+                    >
+                      Clear
+                    </Button>
+                  </div>
+                </Form>
+              </Card>
+            </Col>
+          </Row>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/client/src/views/DashboardLayout.tsx
+++ b/client/src/views/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import {
   BsGrid,
   BsBuilding,
+  BsPeople,
   BsFolder,
   BsFileEarmarkText,
   BsChatDots,
@@ -46,6 +47,7 @@ export function DashboardLayout({ role, children }: DashboardLayoutProps) {
       ? [
           { label: 'Dashboard', icon: BsGrid, to: '/admin' },
           { label: 'Apartments & Tenants', icon: BsBuilding, to: '/admin/apartments' },
+          { label: 'Users', icon: BsPeople, to: '/admin/users' },
           { label: 'Lease Details', icon: BsFileEarmarkText, to: '/admin/lease' },
           { label: 'Complaints', icon: BsChatDots, to: '/admin/complaints' },
         ]


### PR DESCRIPTION
## Summary
- add admin create-user API method in client API layer
- add a new admin page with create-user form for name, email, role, password, and confirmation
- wire route protection and admin sidebar/dashboard navigation to the new page

## Testing
- cd client && npm run build

closes #41