### PR TITLE
[M2][Complaints][Backend] Create complaint_status_histories and complaint_comments migrations

### DIFF
--- a/server/database/migrations/2026_03_23_203721_create_complaint_status_histories_table.php
+++ b/server/database/migrations/2026_03_23_203721_create_complaint_status_histories_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateComplaintStatusHistoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('complaint_status_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('complaint_id')->constrained('complaints')->cascadeOnDelete();
+            $table->enum('old_status', ['pending', 'in_progress', 'resolved'])->nullable();
+            $table->enum('new_status', ['pending', 'in_progress', 'resolved']);
+            $table->foreignId('changed_by_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamp('changed_at');
+            $table->index(['complaint_id', 'changed_at']);
+            $table->index('complaint_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('complaint_status_histories');
+    }
+}

--- a/server/database/migrations/2026_03_23_203724_create_complaint_comments_table.php
+++ b/server/database/migrations/2026_03_23_203724_create_complaint_comments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateComplaintCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('complaint_comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('complaint_id')->constrained('complaints')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->text('comment');
+            $table->timestamps();
+            $table->index('complaint_id');
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('complaint_comments');
+    }
+}


### PR DESCRIPTION
## Summary
Add two supporting migration files for the Complaint module:
- complaint_status_histories: Audit trail for status changes
- complaint_comments: Administrative notes on complaints

## Tests
✅ complaint_status_histories migration: Passed (88.63ms)
✅ complaint_comments migration: Passed (68.62ms)
✅ Foreign key relationships verified
✅ Indexes created for join performance

closes #66