### PR TITLE
[M2][Complaints][Backend] Create GET tenant complaints list endpoint (paginated)

### DIFF
--- a/server/app/Http/Controllers/Api/ComplaintController.php
+++ b/server/app/Http/Controllers/Api/ComplaintController.php
@@ -14,9 +14,15 @@ class ComplaintController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        //
+        $perPage = $request->query('per_page', 15);
+        
+        $complaints = Complaint::where('tenant_id', Auth::id())
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage);
+        
+        return response()->json($complaints, 200);
     }
 
     /**

--- a/server/routes/api.php
+++ b/server/routes/api.php
@@ -32,5 +32,6 @@ Route::post('/attendance', [SessionController::class, 'submitAttendance']);
 
 // Complaint routes
 Route::middleware(['auth:sanctum'])->group(function () {
+    Route::get('/complaints', [ComplaintController::class, 'index']);
     Route::post('/complaints', [ComplaintController::class, 'store']);
 });


### PR DESCRIPTION
## Summary
Add GET /api/complaints endpoint for authenticated tenants to retrieve their paginated complaints.

## Implementation
✅ ComplaintController@index() implemented
✅ Filters complaints by Auth::id() (tenant_id)
✅ Supports per_page query parameter (default 15)
✅ Ordered by created_at descending
✅ Uses Laravel pagination helper for metadata
✅ Route registered: GET /api/complaints

## Route Verification
✅ Both GET and POST routes confirmed via php artisan route:list
✅ Syntax validation passed

## Features
- Paginated response with metadata
- Only returns complaints for authenticated user
- Configurable items per page
- Newest complaints first

closes #72